### PR TITLE
[Feat] 게시글 작성 페이지에 썸네일 & 요약 입력 UI 추가

### DIFF
--- a/src/components/post-write/draft-list-dialog.tsx
+++ b/src/components/post-write/draft-list-dialog.tsx
@@ -1,10 +1,4 @@
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import type { Draft } from "@/features/post/types/draft.types";
@@ -25,13 +19,7 @@ function formatDate(dateString: string): string {
   });
 }
 
-function DraftItem({
-  draft,
-  onSelect,
-}: {
-  draft: Draft;
-  onSelect: (draft: Draft) => void;
-}): React.ReactElement {
+function DraftItem({ draft, onSelect }: { draft: Draft; onSelect: (draft: Draft) => void }): React.ReactElement {
   function handleClick(): void {
     onSelect(draft);
   }
@@ -46,27 +34,21 @@ function DraftItem({
         <h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
           {draft.title.trim() ? draft.title : "제목 없음"}
         </h3>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {formatDate(draft.savedAt)}
-        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">{formatDate(draft.savedAt)}</span>
       </div>
-      {(draft.category || draft.tags.length > 0) ? (
+      {draft.category || draft.tags.length > 0 ? (
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
           {draft.category ? (
-            <span className="text-xs text-muted-foreground">
-              {draft.category}
-            </span>
+            <span className="min-w-0 truncate text-xs text-muted-foreground">{draft.category}</span>
           ) : null}
-          {draft.category && draft.tags.length > 0 ? (
-            <span className="text-xs text-muted-foreground">·</span>
-          ) : null}
+          {draft.category && draft.tags.length > 0 ? <span className="text-xs text-muted-foreground">·</span> : null}
           {draft.tags.map((tag) => (
             <Badge
               key={tag}
               variant="secondary"
-              className="px-2 py-0.5 text-xs text-[#305CEC] dark:text-[#5B7FFF]"
+              className="max-w-full min-w-0 px-2 py-0.5 text-xs text-[#305CEC] dark:text-[#5B7FFF]"
             >
-              {tag}
+              <span className="min-w-0 truncate">{tag}</span>
             </Badge>
           ))}
         </div>
@@ -75,10 +57,7 @@ function DraftItem({
   );
 }
 
-export function DraftListDialog({
-  drafts,
-  onSelect,
-}: DraftListDialogProps): React.ReactElement {
+export function DraftListDialog({ drafts, onSelect }: DraftListDialogProps): React.ReactElement {
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -90,13 +69,9 @@ export function DraftListDialog({
         </DialogHeader>
         <div className="flex flex-col gap-2 overflow-y-auto pr-1">
           {drafts.length > 0 ? (
-            drafts.map((draft) => (
-              <DraftItem key={draft.id} draft={draft} onSelect={onSelect} />
-            ))
+            drafts.map((draft) => <DraftItem key={draft.id} draft={draft} onSelect={onSelect} />)
           ) : (
-            <p className="py-8 text-center text-sm text-muted-foreground">
-              임시 저장된 글이 없습니다.
-            </p>
+            <p className="py-8 text-center text-sm text-muted-foreground">임시 저장된 글이 없습니다.</p>
           )}
         </div>
       </DialogContent>

--- a/src/components/post-write/post-editor.tsx
+++ b/src/components/post-write/post-editor.tsx
@@ -58,14 +58,31 @@ export function PostEditor({ content, onChange, className }: Props): React.React
       attributes: {
         class: "post-content post-editor-content outline-none",
       },
-      handleKeyDown: (_view, event) => {
+      handleKeyDown: (_view, event): boolean => {
         if (!editor) return false;
 
-        // Tab: 4칸 공백 삽입
-        if (event.key === "Tab" && !event.shiftKey) {
+        // Tab: 리스트에서는 들여쓰기/내어쓰기, 일반 문맥에서는 4칸 공백 삽입
+        if (event.key === "Tab") {
+          const isInList = editor.isActive("bulletList") || editor.isActive("orderedList");
+
           event.preventDefault();
-          editor.chain().focus().insertContent("\u00A0\u00A0\u00A0\u00A0").run();
-          return true;
+
+          if (isInList) {
+            if (event.shiftKey) {
+              editor.chain().focus().liftListItem("listItem").run();
+              return true;
+            }
+
+            editor.chain().focus().sinkListItem("listItem").run();
+            return true;
+          }
+
+          if (!event.shiftKey) {
+            editor.chain().focus().insertContent("\u00A0\u00A0\u00A0\u00A0").run();
+            return true;
+          }
+
+          return false;
         }
 
         // Backspace: 빈 리스트 항목에서 리스트 해제 → 일반 텍스트 전환

--- a/src/components/post-write/summary-input.tsx
+++ b/src/components/post-write/summary-input.tsx
@@ -1,0 +1,41 @@
+import { POST_SUMMARY_MAX_LENGTH } from "@/features/post/lib/post-write-constraints";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function SummaryInput({ value, onChange }: Props): React.ReactElement {
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>): void {
+    onChange(e.target.value.slice(0, POST_SUMMARY_MAX_LENGTH));
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <label htmlFor="post-summary" className="text-sm font-medium text-muted-foreground">
+          요약
+        </label>
+        <span
+          className={cn(
+            "text-xs text-muted-foreground",
+            value.length >= POST_SUMMARY_MAX_LENGTH && "font-medium text-destructive",
+          )}
+        >
+          {value.length}/{POST_SUMMARY_MAX_LENGTH}
+        </span>
+      </div>
+      <textarea
+        id="post-summary"
+        value={value}
+        onChange={handleChange}
+        maxLength={POST_SUMMARY_MAX_LENGTH}
+        rows={3}
+        placeholder="게시글 목록에 표시될 요약을 입력하세요"
+        className="min-h-24 w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm leading-6 text-foreground shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40"
+      />
+      <p className="text-xs text-muted-foreground">목록 카드에서 2줄로 표시되므로 핵심 내용을 120자 안에 정리하세요.</p>
+    </div>
+  );
+}

--- a/src/components/post-write/tag-input.tsx
+++ b/src/components/post-write/tag-input.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import { RiCloseLine, RiAddLine, RiCheckLine } from "@remixicon/react";
 import { Badge } from "@/components/ui/badge";
+import { POST_TAG_MAX_LENGTH } from "@/features/post/lib/post-write-constraints";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -28,10 +29,14 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
   const showNewTagOption = trimmedInput && !filteredSuggestions.includes(trimmedInput) && !valueSet.has(trimmedInput);
 
   function addTag(tag: string): void {
-    const trimmed = tag.trim();
+    const trimmed = tag.trim().slice(0, POST_TAG_MAX_LENGTH);
     if (!trimmed || valueSet.has(trimmed) || isMaxReached) return;
     onChange([...value, trimmed]);
     setInputValue("");
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    setInputValue(e.target.value.slice(0, POST_TAG_MAX_LENGTH));
   }
 
   function removeTag(tag: string): void {
@@ -54,12 +59,12 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
   }
 
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-2">
       {/* 태그 입력 필드 */}
-      <div className="relative">
+      <div className="relative min-w-0">
         <div
           className={cn(
-            "flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 transition-colors",
+            "flex h-10 min-w-0 items-center gap-2 rounded-lg border border-border bg-background px-3 transition-colors",
             isFocused && "border-ring",
             isMaxReached && "opacity-60"
           )}
@@ -67,7 +72,8 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
           <input
             type="text"
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={handleInputChange}
+            maxLength={POST_TAG_MAX_LENGTH}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setTimeout(() => setIsFocused(false), 150)}
             onKeyDown={handleKeyDown}
@@ -75,7 +81,7 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
             onCompositionEnd={() => { isComposingRef.current = false; }}
             disabled={isMaxReached}
             placeholder={isMaxReached ? "최대 태그 수에 도달했습니다" : "태그 입력 후 Enter"}
-            className="h-full flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
+            className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
           />
           <span className="flex-shrink-0 text-xs text-muted-foreground">
             {value.length}/{maxTags}
@@ -93,10 +99,10 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
                     type="button"
                     onMouseDown={(e) => e.preventDefault()}
                     onClick={() => addTag(suggestion)}
-                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-secondary"
+                    className="flex w-full min-w-0 items-center gap-2 px-4 py-2 text-left text-sm transition-colors hover:bg-secondary"
                   >
-                    <RiCheckLine size={14} className="text-muted-foreground" />
-                    {suggestion}
+                    <RiCheckLine size={14} className="shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 truncate">{suggestion}</span>
                   </button>
                 ))}
               </div>
@@ -107,10 +113,10 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
                   type="button"
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => addTag(inputValue)}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                  className="flex w-full min-w-0 items-center gap-2 px-4 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
                 >
-                  <RiAddLine size={14} />
-                  &quot;{inputValue.trim()}&quot; 태그 추가
+                  <RiAddLine size={14} className="shrink-0" />
+                  <span className="min-w-0 truncate">&quot;{inputValue.trim()}&quot; 태그 추가</span>
                 </button>
               </div>
             )}
@@ -120,18 +126,19 @@ export function TagInput({ value, onChange, suggestions, maxTags = MAX_TAGS_DEFA
 
       {/* rendering-conditional-render: 삼항 연산자 사용 */}
       {value.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex min-w-0 flex-wrap gap-2">
           {value.map((tag) => (
             <Badge
               key={tag}
               variant="secondary"
-              className="gap-1 px-3 py-1 text-xs text-[#305CEC] dark:text-[#5B7FFF]"
+              className="max-w-full min-w-0 gap-1 px-3 py-1 text-xs text-[#305CEC] dark:text-[#5B7FFF]"
             >
-              {tag}
+              <span className="min-w-0 truncate">{tag}</span>
               <button
                 type="button"
                 onClick={() => removeTag(tag)}
-                className="flex items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                className="flex shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                aria-label={`${tag} 태그 삭제`}
               >
                 <RiCloseLine size={14} />
               </button>

--- a/src/components/post-write/thumbnail-input.tsx
+++ b/src/components/post-write/thumbnail-input.tsx
@@ -1,0 +1,109 @@
+import { ImagePlus, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  THUMBNAIL_ACCEPT,
+  THUMBNAIL_ACCEPTED_TYPES,
+  THUMBNAIL_TARGET_HEIGHT,
+  THUMBNAIL_TARGET_WIDTH,
+} from "@/features/post/lib/post-write-constraints";
+
+type ThumbnailValue = {
+  file: File | null;
+  previewUrl: string;
+};
+
+type Props = {
+  value: ThumbnailValue;
+  onChange: (value: ThumbnailValue) => void;
+};
+
+export function ThumbnailInput({ value, onChange }: Props): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState("");
+
+  function handleClick(): void {
+    inputRef.current?.click();
+  }
+
+  function handleRemove(): void {
+    setError("");
+    if (inputRef.current) inputRef.current.value = "";
+    onChange({ file: null, previewUrl: "" });
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!THUMBNAIL_ACCEPTED_TYPES.includes(file.type as (typeof THUMBNAIL_ACCEPTED_TYPES)[number])) {
+      setError("JPG, PNG, WebP 이미지만 등록할 수 있습니다.");
+      e.target.value = "";
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.onload = () => {
+      setError("");
+      onChange({ file, previewUrl });
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(previewUrl);
+      setError("이미지를 불러올 수 없습니다. 다른 파일을 선택하세요.");
+      e.target.value = "";
+    };
+
+    image.src = previewUrl;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <label className="text-sm font-medium text-muted-foreground">썸네일</label>
+        {value.previewUrl ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleRemove}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 />
+            삭제
+          </Button>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleClick}
+        className="group relative flex aspect-[23/16] w-full items-center justify-center overflow-hidden rounded-md border border-dashed border-border bg-secondary/40 text-left transition-colors hover:border-ring hover:bg-secondary focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+      >
+        {value.previewUrl ? (
+          <img
+            src={value.previewUrl}
+            alt="선택한 썸네일 미리보기"
+            className="size-full object-cover transition-transform group-hover:scale-[1.02]"
+          />
+        ) : (
+          <span className="flex flex-col items-center gap-2 px-4 text-center text-sm text-muted-foreground">
+            <ImagePlus className="size-6" />
+            썸네일 이미지 선택
+          </span>
+        )}
+      </button>
+
+      <input ref={inputRef} type="file" accept={THUMBNAIL_ACCEPT} onChange={handleFileChange} className="sr-only" />
+
+      <div className="space-y-1">
+        <p className="text-xs text-muted-foreground">
+          저장 시 목록 비율({THUMBNAIL_TARGET_WIDTH}x{THUMBNAIL_TARGET_HEIGHT})에 맞춰 리사이즈 후 중앙 기준으로 잘라내는 방식이 적합합니다.
+        </p>
+        {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -28,8 +28,8 @@ export function PostCard({ post, isLast = false }: PostCardProps): React.ReactEl
         <div className="mt-3 flex flex-col gap-3">
           <div className="flex flex-wrap gap-3">
             {post.tags.map((tag) => (
-              <Badge key={tag} variant="secondary" className="px-3 py-1 text-xs text-[#305CEC] dark:text-[#5B7FFF]">
-                {tag}
+              <Badge key={tag} variant="secondary" className="max-w-full min-w-0 px-3 py-1 text-xs text-[#305CEC] dark:text-[#5B7FFF]">
+                <span className="min-w-0 truncate">{tag}</span>
               </Badge>
             ))}
           </div>

--- a/src/features/post/lib/post-write-constraints.ts
+++ b/src/features/post/lib/post-write-constraints.ts
@@ -1,0 +1,9 @@
+export const POST_SUMMARY_MAX_LENGTH = 120;
+export const POST_TAG_MAX_LENGTH = 24;
+
+export const THUMBNAIL_TARGET_WIDTH = 460;
+export const THUMBNAIL_TARGET_HEIGHT = 320;
+
+export const THUMBNAIL_ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
+export const THUMBNAIL_ACCEPT = THUMBNAIL_ACCEPTED_TYPES.join(",");

--- a/src/features/post/types/draft.types.ts
+++ b/src/features/post/types/draft.types.ts
@@ -1,6 +1,8 @@
 export interface Draft {
   id: string;
   title: string;
+  summary?: string;
+  thumbnailUrl?: string;
   category: string;
   tags: string[];
   content: string;

--- a/src/features/post/types/post-write.types.ts
+++ b/src/features/post/types/post-write.types.ts
@@ -1,5 +1,8 @@
 export interface PostWriteForm {
   title: string;
+  summary: string;
+  thumbnailFile: File | null;
+  thumbnailUrl: string;
   category: string;
   tags: string[];
   content: string;

--- a/src/index.css
+++ b/src/index.css
@@ -228,8 +228,32 @@
   @apply my-4 list-disc pl-6;
 }
 
+.post-content ul ul {
+  @apply my-1 list-[circle];
+}
+
+.post-content ul ul ul {
+  @apply list-[square];
+}
+
+.post-content ul ul ul ul {
+  @apply list-disc;
+}
+
 .post-content ol {
   @apply my-4 list-decimal pl-6;
+}
+
+.post-content ol ol {
+  @apply my-1 list-[lower-alpha];
+}
+
+.post-content ol ol ol {
+  @apply list-[lower-roman];
+}
+
+.post-content ol ol ol ol {
+  @apply list-decimal;
 }
 
 .post-content li {
@@ -501,7 +525,7 @@
 
 /* Code block within editor */
 .post-editor-content pre {
-  @apply my-6 overflow-hidden rounded-xl p-4 font-mono text-sm;
+  @apply my-6 overflow-hidden rounded-xl p-0 font-mono text-sm;
   background: #fafafa;
 }
 
@@ -510,8 +534,27 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.post-editor-content pre::before {
+  @apply block h-11 border-b border-black/5;
+  content: "";
+  background:
+    radial-gradient(circle at 18px 50%, #ff5f57 0 6px, transparent 6.5px),
+    radial-gradient(circle at 40px 50%, #febc2e 0 6px, transparent 6.5px),
+    radial-gradient(circle at 62px 50%, #28c840 0 6px, transparent 6.5px),
+    #f0f0f0;
+}
+
+.dark .post-editor-content pre::before {
+  border-color: rgba(255, 255, 255, 0.05);
+  background:
+    radial-gradient(circle at 18px 50%, #ff5f57 0 6px, transparent 6.5px),
+    radial-gradient(circle at 40px 50%, #febc2e 0 6px, transparent 6.5px),
+    radial-gradient(circle at 62px 50%, #28c840 0 6px, transparent 6.5px),
+    #242527;
+}
+
 .post-editor-content pre code {
-  @apply block bg-transparent p-0 text-sm leading-relaxed;
+  @apply block overflow-x-auto bg-transparent p-4 text-sm leading-relaxed;
 }
 
 /* Image figure within editor */

--- a/src/routes/posts/write.tsx
+++ b/src/routes/posts/write.tsx
@@ -1,10 +1,13 @@
-import { useState, lazy, Suspense } from "react";
+import { useEffect, useState, lazy, Suspense } from "react";
 import { Navigate } from "react-router-dom";
 import { TitleInput } from "@/components/post-write/title-input";
+import { SummaryInput } from "@/components/post-write/summary-input";
+import { ThumbnailInput } from "@/components/post-write/thumbnail-input";
 import { CategorySelect } from "@/components/post-write/category-select";
 import { TagInput } from "@/components/post-write/tag-input";
 import { DraftListDialog } from "@/components/post-write/draft-list-dialog";
 import { Button } from "@/components/ui/button";
+import { POST_TAG_MAX_LENGTH } from "@/features/post/lib/post-write-constraints";
 import type { PostWriteForm } from "@/features/post/types/post-write.types";
 import type { Draft } from "@/features/post/types/draft.types";
 import { useAuthStatus } from "@/features/admin-auth/hooks/queries/use-auth-status";
@@ -123,16 +126,39 @@ export function PostWritePage(): React.ReactElement | null {
 
   const [form, setForm] = useState<PostWriteForm>({
     title: "",
+    summary: "",
+    thumbnailFile: null,
+    thumbnailUrl: "",
     category: "",
     tags: [],
     content: "",
   });
+
+  useEffect(() => {
+    const previewUrl = form.thumbnailUrl;
+
+    return () => {
+      if (previewUrl.startsWith("blob:")) URL.revokeObjectURL(previewUrl);
+    };
+  }, [form.thumbnailUrl]);
 
   if (isAuthLoading) return null;
   if (!isAuthenticated) return <Navigate to="/admin" replace />;
 
   function handleTitleChange(title: string): void {
     setForm((prev) => ({ ...prev, title }));
+  }
+
+  function handleSummaryChange(summary: string): void {
+    setForm((prev) => ({ ...prev, summary }));
+  }
+
+  function handleThumbnailChange(value: { file: File | null; previewUrl: string }): void {
+    setForm((prev) => ({
+      ...prev,
+      thumbnailFile: value.file,
+      thumbnailUrl: value.previewUrl,
+    }));
   }
 
   function handleCategoryChange(category: string): void {
@@ -150,6 +176,16 @@ export function PostWritePage(): React.ReactElement | null {
   function handleDraftSelect(draft: Draft): void {
     // TODO: 추후 API 연동
     console.log("불러오기:", draft);
+    setForm((prev) => ({
+      ...prev,
+      title: draft.title,
+      summary: draft.summary ?? "",
+      thumbnailFile: null,
+      thumbnailUrl: draft.thumbnailUrl ?? "",
+      category: draft.category,
+      tags: draft.tags,
+      content: draft.content,
+    }));
   }
 
   function handleDraft(): void {
@@ -168,9 +204,20 @@ export function PostWritePage(): React.ReactElement | null {
         {/* 제목 */}
         <TitleInput value={form.title} onChange={handleTitleChange} />
 
+        {/* 목록 미리보기 정보 */}
+        <div className="space-y-5">
+          <SummaryInput value={form.summary} onChange={handleSummaryChange} />
+          <div className="max-w-[460px]">
+            <ThumbnailInput
+              value={{ file: form.thumbnailFile, previewUrl: form.thumbnailUrl }}
+              onChange={handleThumbnailChange}
+            />
+          </div>
+        </div>
+
         {/* 카테고리 & 태그 */}
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-2">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="min-w-0 space-y-2">
             <label className="text-sm font-medium text-muted-foreground">카테고리</label>
             <CategorySelect
               value={form.category}
@@ -178,8 +225,13 @@ export function PostWritePage(): React.ReactElement | null {
               categories={MOCK_CATEGORIES}
             />
           </div>
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-muted-foreground">태그</label>
+          <div className="min-w-0 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <label className="text-sm font-medium text-muted-foreground">태그</label>
+              <span className="truncate text-xs text-muted-foreground">
+                태그는 최대 {POST_TAG_MAX_LENGTH}자까지 입력할 수 있습니다.
+              </span>
+            </div>
             <TagInput
               value={form.tags}
               onChange={handleTagsChange}


### PR DESCRIPTION
## 📌 작업 내용
- 게시글 작성 페이지에 썸네일 & 요약 입력 UI 추가
- 게시글 페이지 UI/UX 수정 

## 🔗 관련 이슈
- close #22

## 🧩 개발 사항
- 게시글 작성 페이지에 썸네일 & 요약 입력 UI 추가
- 태그 입력 글자수 제한 및 태그 글자수가 많을 시 레이아웃 늘어나는 현상 방지
- 에디터 코드 블록 스타일을 상세 페이지와 비슷하게 렌더링 되도록 수정
- 에디터에서 중첩 리스트 사용시 들여쓰기 효과 반영되도록 변경  

